### PR TITLE
Remove Glimmer AST Deprecation

### DIFF
--- a/strip-test-selectors.js
+++ b/strip-test-selectors.js
@@ -18,12 +18,12 @@ module.exports = function () {
       },
 
       MustacheStatement(node) {
-        node.params = node.params.filter(param => !isTestSelector(param.original));
+        node.params = node.params.filter(param => !isTestSelector(param.value));
         node.hash.pairs = node.hash.pairs.filter(pair => !isTestSelector(pair.key));
       },
 
       BlockStatement(node) {
-        node.params = node.params.filter(param => !isTestSelector(param.original));
+        node.params = node.params.filter(param => !isTestSelector(param.value));
         node.hash.pairs = node.hash.pairs.filter(pair => !isTestSelector(pair.key));
       },
     },


### PR DESCRIPTION
Accessing this value in original is deprecated, and very noisily so, replacing this with value as recommended.

Deprecation Message:
`DEPRECATION: The original property on literal nodes is deprecated, use value instead`

Fixes #1219